### PR TITLE
build: add pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ RELEASE.md
 
 # Claude Code local settings
 .claude/
+
+# API reference docs (local copies)
+*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pdf_shift-*.tar
 
 # Ignore Expublish artefacts
 RELEASE.md
+
+# Claude Code local settings
+.claude/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  // Exclude generated/vendored directories and files managed by tooling
+  "ignores": ["CHANGELOG.md", ".claude/", "_build/", "deps/"],
+  "config": {
+    // Badge URLs and long code examples exceed 80 chars
+    "MD013": false,
+    // CHANGELOG repeats section names (## Added, ## Fixed) across versions
+    "MD024": false
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `ex_pdf_shift` is an Elixir client library (hex package: `pdf_shift`) for the [PDFShift API](https://pdfshift.io), which converts HTML/URLs to PDF. It is a standalone library — not a Phoenix application.
 
-## Commands
+## Development
+
+### Setup
+
+Run `bin/setup` to install system dependencies (via Homebrew) and register git hooks:
+
+- [actionlint](https://github.com/rhysd/actionlint) — GitHub Actions linter
+- [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema) — validates workflow, Dependabot, and release-please configs
+- [lefthook](https://github.com/evilmartians/lefthook) — git hook manager
+- [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) — Markdown linter
+
+Then run `mix deps.get` to install Elixir dependencies.
+
+### Commands
 
 - Install dependencies: `mix deps.get`
 - Run all tests: `mix test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+`ex_pdf_shift` is an Elixir client library (hex package: `pdf_shift`) for the [PDFShift API](https://pdfshift.io), which converts HTML/URLs to PDF. It is a standalone library — not a Phoenix application.
+
+## Commands
+
+- Install dependencies: `mix deps.get`
+- Run all tests: `mix test`
+- Run a single test file: `mix test test/pdf_shift/client_test.exs`
+- Run a single test: `mix test test/pdf_shift/client_test.exs:42`
+- Lint: `mix credo`
+- Format: `mix format`
+- Generate docs: `mix docs`
+
+## Architecture
+
+The library is a thin HTTP wrapper with clean layering:
+
+```text
+PDFShift (public API)
+  └─> PDFShift.API (endpoint definitions)
+        └─> PDFShift.Client (HTTP via Req)
+```
+
+- **`PDFShift`** — public interface; `convert/3` and `credits_usage/1`. Loads the client module from `Application.get_env(:pdf_shift, :client_module, PDFShift.Client)` to allow test injection.
+- **`PDFShift.API`** — maps functions to PDFShift v3 endpoints (`/convert/pdf`, `/credits/usage`).
+- **`PDFShift.Client`** — implements `PDFShift.ClientBehaviour`; uses `Req` with HTTP Basic Auth (`api:<key>`), JSON encoding, and configurable timeouts (30s GET, 60s POST).
+- **`PDFShift.Config`** — builds config struct from keyword opts or `PDFSHIFT_API_KEY` env var.
+- **`PDFShift.Types`** — typespecs for all conversion options and response shapes.
+
+## Testing
+
+Tests use **Mox** for unit tests (via `PDFShift.MockClient`) and **Bypass** for HTTP-level integration tests. Test setup in `test/test_helper.exs` configures the app to use `MockClient` and enables `test_mode` (disables Req retries).
+
+- `test/support/helper.ex` — shared fixtures: `test_config/0`, `sample_pdf_binary/0`, `success_convert_response/0`, etc.
+- `test/support/mocks.ex` — defines `PDFShift.MockClient` via `Mox.defmock/2`.
+
+## Code Style
+
+- Add `@moduledoc` / `@doc` and typespecs to all public functions.
+- Update typespecs when editing function signatures.
+- Handle errors with pattern matching and `{:ok, _}` / `{:error, _}` tuples.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Set your API key using one of these methods:
 
 1. Set the `PDFSHIFT_API_KEY` environment variable
 2. Pass the API key in the options to each function
+
    ```elixir
    PDFShift.convert("https://example.com", %{}, api_key: "your_api_key")
    ```
@@ -110,9 +111,33 @@ The following options can be passed to the `convert/3` function:
 
 ## Development
 
-After checking out the repo, run `mix deps.get` to install dependencies. Then, run `mix test` to run the tests.
+### Setup
+
+Run the setup script to install system dependencies and register git hooks:
+
+```shell
+bin/setup
+```
+
+This installs [actionlint](https://github.com/rhysd/actionlint), [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema), [lefthook](https://github.com/evilmartians/lefthook), and [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) via Homebrew, then registers the pre-commit hooks.
+
+Then install Elixir dependencies:
+
+```shell
+mix deps.get
+```
+
+### Commands
+
+| Task | Command |
+| ---- | ------- |
+| Run tests | `mix test` |
+| Run a single test file | `mix test test/pdf_shift/client_test.exs` |
+| Run a single test | `mix test test/pdf_shift/client_test.exs:42` |
+| Lint | `mix credo` |
+| Format | `mix format` |
+| Generate docs | `mix docs` |
 
 ## License
 
 The package is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+brew install actionlint check-jsonschema lefthook markdownlint-cli2
+lefthook install

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,24 @@
+pre-commit:
+  parallel: true
+  commands:
+    mix-format:
+      glob: "*.{ex,exs}"
+      run: mix format --check-formatted
+    actionlint:
+      glob: ".github/workflows/*.yml"
+      run: actionlint {staged_files}
+    check-github-workflows:
+      glob: ".github/workflows/*.yml"
+      run: check-jsonschema --builtin-schema vendor.github-workflows {staged_files}
+    check-dependabot:
+      glob: ".github/dependabot.{yml,yaml}"
+      run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}
+    check-release-please-config:
+      glob: "release-please-config.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json {staged_files}
+    check-release-please-manifest:
+      glob: ".release-please-manifest.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json {staged_files}
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add [lefthook](https://github.com/evilmartians/lefthook) for pre-commit hook management with checks for Elixir formatting, GitHub Actions workflow validity, Dependabot config, release-please config/manifest, and Markdown linting
- Add `.markdownlint-cli2.jsonc` config excluding generated files (`CHANGELOG.md`, `_build/`, `deps/`, `.claude/`) and disabling MD013 (line length) and MD024 (duplicate headings)
- Add `bin/setup` script to install hook dependencies via Homebrew and register the hooks
- Add `CLAUDE.md` with project guidance for Claude Code
- Ignore `.claude/` (local Claude Code settings) and `*.pdf` files via `.gitignore`