### PR TITLE
docs: fix credits function name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ PDFShift.convert("https://example.com", %{
 ### Check credit usage
 
 ```elixir
-PDFShift.credits()
+PDFShift.credits_usage()
 ```
 
 ## Available options

--- a/lib/pdf_shift.ex
+++ b/lib/pdf_shift.ex
@@ -39,7 +39,7 @@ defmodule PDFShift do
 
   Checking credit usage:
   ```elixir
-  PDFShift.credits()
+  PDFShift.credits_usage()
   ```
   """
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Correct `PDFShift.credits()` to `PDFShift.credits_usage()` in README example
- Fix the same stale reference in `PDFShift` moduledoc