### PR TITLE
fix: correct zoom option typespec to number()

### DIFF
--- a/lib/pdf_shift/types.ex
+++ b/lib/pdf_shift/types.ex
@@ -102,7 +102,7 @@ defmodule PDFShift.Types do
           optional(:use_print) => boolean(),
           optional(:format) => String.t(),
           optional(:pages) => String.t(),
-          optional(:zoom) => integer(),
+          optional(:zoom) => number(),
           optional(:is_gdpr) => boolean(),
           optional(:is_hipaa) => boolean(),
           optional(:margin) => margin(),


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Change `zoom` field in `convert_options()` from `integer()` to `number()`, reflecting that the API accepts float values between 0 and 2 (e.g. `1.5`)