### PR TITLE
test: use non-routable URL in test helper config

### DIFF
--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -5,7 +5,7 @@ defmodule PDFShift.Test.Helper do
   Creates a test configuration.
   """
   def test_config do
-    PDFShift.Config.new(api_key: "test_api_key", base_url: "https://api.pdfshift.io/v3")
+    PDFShift.Config.new(api_key: "test_api_key", base_url: "https://api.pdfshift.test")
   end
 
   @doc """


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace the production `api.pdfshift.io` URL in `test_config/0` with an obviously fake `.test` domain, preventing any misconfigured test from accidentally reaching the real API