### PR TITLE
fix: use safe_transient retry strategy instead of infinite retry

### DIFF
--- a/lib/pdf_shift/client.ex
+++ b/lib/pdf_shift/client.ex
@@ -46,7 +46,7 @@ defmodule PDFShift.Client do
       # No retries in test mode to speed up tests
       false
     else
-      fn _attempt, _error -> true end
+      :safe_transient
     end
   end
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace `fn _attempt, _error -> true end` (retries forever) with Req's built-in `:safe_transient` strategy, which retries only on transient network errors with exponential backoff (up to 3 attempts)
- Prevents runaway requests on persistent failures while still recovering from genuine transient errors