### PR TITLE
refactor: remove redundant manual JSON decode in handle_response

### DIFF
--- a/lib/pdf_shift/client.ex
+++ b/lib/pdf_shift/client.ex
@@ -50,18 +50,7 @@ defmodule PDFShift.Client do
     end
   end
 
-  defp handle_response({:ok, %{status: status, body: body} = response}) when status in 200..299 do
-    # For successful API calls, try to parse JSON body if it's a string
-    response =
-      if is_binary(body) do
-        case Jason.decode(body) do
-          {:ok, decoded} -> %{response | body: decoded}
-          _ -> response
-        end
-      else
-        response
-      end
-
+  defp handle_response({:ok, %{status: status} = response}) when status in 200..299 do
     {:ok, response}
   end
 

--- a/test/pdf_shift/client_test.exs
+++ b/test/pdf_shift/client_test.exs
@@ -21,7 +21,9 @@ defmodule PDFShift.ClientTest do
   describe "get/3" do
     test "handles successful response", %{bypass: bypass, config: config} do
       Bypass.expect(bypass, "GET", "/test-endpoint", fn conn ->
-        Plug.Conn.resp(conn, 200, Jason.encode!(%{success: true, data: "test"}))
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{success: true, data: "test"}))
       end)
 
       {:ok, response} =
@@ -34,7 +36,9 @@ defmodule PDFShift.ClientTest do
 
     test "handles error response", %{bypass: bypass, config: config} do
       Bypass.expect(bypass, "GET", "/test-endpoint", fn conn ->
-        Plug.Conn.resp(conn, 401, Jason.encode!(%{success: false, error: "Invalid API key"}))
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(401, Jason.encode!(%{success: false, error: "Invalid API key"}))
       end)
 
       assert {:error, "Invalid API key"} ==
@@ -57,7 +61,9 @@ defmodule PDFShift.ClientTest do
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         assert Jason.decode!(body) == %{"key" => "value"}
 
-        Plug.Conn.resp(conn, 200, Jason.encode!(%{success: true, data: "test"}))
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{success: true, data: "test"}))
       end)
 
       {:ok, response} =
@@ -72,7 +78,9 @@ defmodule PDFShift.ClientTest do
 
     test "handles error response", %{bypass: bypass, config: config} do
       Bypass.expect(bypass, "POST", "/test-endpoint", fn conn ->
-        Plug.Conn.resp(conn, 401, Jason.encode!(%{success: false, error: "Invalid API key"}))
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(401, Jason.encode!(%{success: false, error: "Invalid API key"}))
       end)
 
       assert {:error, "Invalid API key"} ==


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove manual `Jason.decode/1` call in the success branch of `handle_response/1` — Req already decodes JSON responses automatically when the server sets `Content-Type: application/json`
- Update Bypass test handlers to set `Content-Type: application/json`, matching what the real API sends and enabling Req's built-in decoding in tests