### PR TITLE
refactor!: make get_api_key_from_env/0 private

### DIFF
--- a/lib/pdf_shift/config.ex
+++ b/lib/pdf_shift/config.ex
@@ -36,11 +36,7 @@ defmodule PDFShift.Config do
     }
   end
 
-  @doc """
-  Gets the API key from environment variables.
-  """
-  @spec get_api_key_from_env() :: String.t() | nil
-  def get_api_key_from_env do
+  defp get_api_key_from_env do
     System.get_env("PDFSHIFT_API_KEY")
   end
 end

--- a/test/pdf_shift/config_test.exs
+++ b/test/pdf_shift/config_test.exs
@@ -15,18 +15,27 @@ defmodule PDFShift.ConfigTest do
       assert config.base_url == "https://custom-api.example.com"
       assert config.api_key == "test_api_key"
     end
-  end
 
-  describe "get_api_key_from_env/0" do
-    test "returns nil when environment variable is not set" do
-      System.delete_env("PDFSHIFT_API_KEY")
-      assert Config.get_api_key_from_env() == nil
+    test "reads api_key from PDFSHIFT_API_KEY environment variable" do
+      System.put_env("PDFSHIFT_API_KEY", "env_api_key")
+
+      try do
+        config = Config.new()
+        assert config.api_key == "env_api_key"
+      after
+        System.delete_env("PDFSHIFT_API_KEY")
+      end
     end
 
-    test "returns the API key from environment variable" do
+    test "explicit api_key option takes precedence over environment variable" do
       System.put_env("PDFSHIFT_API_KEY", "env_api_key")
-      assert Config.get_api_key_from_env() == "env_api_key"
-      System.delete_env("PDFSHIFT_API_KEY")
+
+      try do
+        config = Config.new(api_key: "explicit_key")
+        assert config.api_key == "explicit_key"
+      after
+        System.delete_env("PDFSHIFT_API_KEY")
+      end
     end
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Change `get_api_key_from_env/0` from `def` to `defp` — it is an implementation detail of `Config.new/1`, not part of the public API
- Remove the dedicated `describe "get_api_key_from_env/0"` test block and replace with equivalent coverage in `describe "new/1"`, testing the observable behaviour rather than the private helper directly