### PR TITLE
refactor: remove unused client_opts parameter from API module

### DIFF
--- a/lib/pdf_shift/api.ex
+++ b/lib/pdf_shift/api.ex
@@ -14,7 +14,7 @@ defmodule PDFShift.API do
     * `client` - The HTTP client module
     * `config` - The configuration struct
     * `source` - URL or HTML content to convert to PDF
-    * `options` - Additional options for the conversion
+    * `options` - Conversion options (see `PDFShift.Types.convert_options/0`)
 
   ## Returns
 
@@ -27,12 +27,12 @@ defmodule PDFShift.API do
       {:ok, %{body: <<PDF binary data>>, status: 200, headers: [...]}}
 
   """
-  @spec convert(module(), Config.t(), String.t(), Types.convert_options(), keyword()) ::
+  @spec convert(module(), Config.t(), String.t(), Types.convert_options()) ::
           {:ok, map()} | {:error, any()}
-  def convert(client, config, source, options \\ %{}, client_opts \\ []) do
+  def convert(client, config, source, options \\ %{}) do
     payload = Map.put(options, :source, source)
 
-    client.post(config, "/convert/pdf", payload, client_opts)
+    client.post(config, "/convert/pdf", payload, [])
   end
 
   @doc """
@@ -66,8 +66,8 @@ defmodule PDFShift.API do
       }}
 
   """
-  @spec credits_usage(module(), Config.t(), keyword()) :: {:ok, map()} | {:error, any()}
-  def credits_usage(client, config, client_opts \\ []) do
-    client.get(config, "/credits/usage", client_opts)
+  @spec credits_usage(module(), Config.t()) :: {:ok, map()} | {:error, any()}
+  def credits_usage(client, config) do
+    client.get(config, "/credits/usage", [])
   end
 end

--- a/lib/pdf_shift/api.ex
+++ b/lib/pdf_shift/api.ex
@@ -14,7 +14,7 @@ defmodule PDFShift.API do
     * `client` - The HTTP client module
     * `config` - The configuration struct
     * `source` - URL or HTML content to convert to PDF
-    * `options` - Conversion options (see `PDFShift.Types.convert_options/0`)
+    * `options` - Conversion options (see `t:PDFShift.Types.convert_options/0`)
 
   ## Returns
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove `client_opts \\ []` from `API.convert/5` (now `convert/4`) and `API.credits_usage/3` (now `credits_usage/2`) — the public `PDFShift` interface never passed these through, making the parameter unreachable
- Pass `[]` directly to the client calls in place of the removed parameter