### PR TITLE
fix: return error from Config.new/1 when api_key is missing

### DIFF
--- a/lib/pdf_shift.ex
+++ b/lib/pdf_shift.ex
@@ -72,10 +72,9 @@ defmodule PDFShift do
   """
   @spec convert(String.t(), Types.convert_options(), keyword()) :: {:ok, map()} | {:error, any()}
   def convert(source, options \\ %{}, config_opts \\ []) do
-    config = Config.new(config_opts)
-    client = client_module()
-
-    API.convert(client, config, source, options)
+    with {:ok, config} <- Config.new(config_opts) do
+      API.convert(client_module(), config, source, options)
+    end
   end
 
   @doc """
@@ -105,10 +104,9 @@ defmodule PDFShift do
   """
   @spec credits_usage(keyword()) :: {:ok, map()} | {:error, any()}
   def credits_usage(config_opts \\ []) do
-    config = Config.new(config_opts)
-    client = client_module()
-
-    API.credits_usage(client, config)
+    with {:ok, config} <- Config.new(config_opts) do
+      API.credits_usage(client_module(), config)
+    end
   end
 
   defp client_module do

--- a/lib/pdf_shift/config.ex
+++ b/lib/pdf_shift/config.ex
@@ -14,6 +14,8 @@ defmodule PDFShift.Config do
   @doc """
   Creates a new configuration with the given options.
 
+  Returns `{:error, reason}` if no API key is available.
+
   ## Options
 
     * `:api_key` - API key for authentication with PDFShift
@@ -22,18 +24,22 @@ defmodule PDFShift.Config do
   ## Examples
 
       iex> PDFShift.Config.new(api_key: "api_key123")
-      %PDFShift.Config{api_key: "api_key123", base_url: "https://api.pdfshift.io/v3"}
+      {:ok, %PDFShift.Config{api_key: "api_key123", base_url: "https://api.pdfshift.io/v3"}}
+
+      iex> PDFShift.Config.new()
+      {:error, "API key is required. Pass api_key: \"...\" or set PDFSHIFT_API_KEY."}
 
   """
-  @spec new(keyword()) :: t()
+  @spec new(keyword()) :: {:ok, t()} | {:error, String.t()}
   def new(opts \\ []) do
     api_key = Keyword.get(opts, :api_key) || get_api_key_from_env()
     base_url = Keyword.get(opts, :base_url, "https://api.pdfshift.io/v3")
 
-    %__MODULE__{
-      api_key: api_key,
-      base_url: base_url
-    }
+    if api_key do
+      {:ok, %__MODULE__{api_key: api_key, base_url: base_url}}
+    else
+      {:error, "API key is required. Pass api_key: \"...\" or set PDFSHIFT_API_KEY."}
+    end
   end
 
   defp get_api_key_from_env do

--- a/test/pdf_shift/config_test.exs
+++ b/test/pdf_shift/config_test.exs
@@ -4,23 +4,30 @@ defmodule PDFShift.ConfigTest do
   alias PDFShift.Config
 
   describe "new/1" do
-    test "creates a new config with defaults" do
-      config = Config.new()
-      assert config.base_url == "https://api.pdfshift.io/v3"
-      assert config.api_key == nil
+    test "returns error when no api_key is available" do
+      System.delete_env("PDFSHIFT_API_KEY")
+      assert {:error, reason} = Config.new()
+      assert reason =~ "API key is required"
     end
 
-    test "creates a new config with provided options" do
-      config = Config.new(api_key: "test_api_key", base_url: "https://custom-api.example.com")
+    test "creates a new config with provided api_key" do
+      assert {:ok, config} =
+               Config.new(api_key: "test_api_key", base_url: "https://custom-api.example.com")
+
       assert config.base_url == "https://custom-api.example.com"
       assert config.api_key == "test_api_key"
+    end
+
+    test "uses default base_url when not provided" do
+      assert {:ok, config} = Config.new(api_key: "test_api_key")
+      assert config.base_url == "https://api.pdfshift.io/v3"
     end
 
     test "reads api_key from PDFSHIFT_API_KEY environment variable" do
       System.put_env("PDFSHIFT_API_KEY", "env_api_key")
 
       try do
-        config = Config.new()
+        assert {:ok, config} = Config.new()
         assert config.api_key == "env_api_key"
       after
         System.delete_env("PDFSHIFT_API_KEY")
@@ -31,7 +38,7 @@ defmodule PDFShift.ConfigTest do
       System.put_env("PDFSHIFT_API_KEY", "env_api_key")
 
       try do
-        config = Config.new(api_key: "explicit_key")
+        assert {:ok, config} = Config.new(api_key: "explicit_key")
         assert config.api_key == "explicit_key"
       after
         System.delete_env("PDFSHIFT_API_KEY")

--- a/test/pdf_shift_test.exs
+++ b/test/pdf_shift_test.exs
@@ -26,7 +26,7 @@ defmodule PDFShiftTest do
         {:ok, response}
       end)
 
-      assert PDFShift.convert("https://example.com") == {:ok, response}
+      assert PDFShift.convert("https://example.com", %{}, api_key: "test_key") == {:ok, response}
     end
 
     test "converts URL to PDF with options", %{success_convert_response: response} do
@@ -40,7 +40,8 @@ defmodule PDFShiftTest do
 
       assert PDFShift.convert(
                "https://example.com",
-               %{landscape: true, format: "A4"}
+               %{landscape: true, format: "A4"},
+               api_key: "test_key"
              ) == {:ok, response}
     end
 
@@ -53,7 +54,12 @@ defmodule PDFShiftTest do
         {:ok, response}
       end)
 
-      assert PDFShift.convert(html) == {:ok, response}
+      assert PDFShift.convert(html, %{}, api_key: "test_key") == {:ok, response}
+    end
+
+    test "returns error when api_key is missing" do
+      System.delete_env("PDFSHIFT_API_KEY")
+      assert {:error, _reason} = PDFShift.convert("https://example.com")
     end
 
     test "uses api_key from options", %{success_convert_response: response} do
@@ -76,7 +82,8 @@ defmodule PDFShiftTest do
         {:error, "API error"}
       end)
 
-      assert PDFShift.convert("https://example.com") == {:error, "API error"}
+      assert PDFShift.convert("https://example.com", %{}, api_key: "test_key") ==
+               {:error, "API error"}
     end
   end
 
@@ -87,7 +94,12 @@ defmodule PDFShiftTest do
         {:ok, response}
       end)
 
-      assert PDFShift.credits_usage() == {:ok, response}
+      assert PDFShift.credits_usage(api_key: "test_key") == {:ok, response}
+    end
+
+    test "returns error when api_key is missing" do
+      System.delete_env("PDFSHIFT_API_KEY")
+      assert {:error, _reason} = PDFShift.credits_usage()
     end
 
     test "uses api_key from options", %{success_credits_response: response} do
@@ -106,7 +118,7 @@ defmodule PDFShiftTest do
         {:error, "API error"}
       end)
 
-      assert PDFShift.credits_usage() == {:error, "API error"}
+      assert PDFShift.credits_usage(api_key: "test_key") == {:error, "API error"}
     end
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Change `Config.new/1` to return `{:ok, config}` on success and `{:error, reason}` when no API key is available (neither passed directly nor via `PDFSHIFT_API_KEY`), so callers get a clear error message instead of a confusing 401 from the API
- Update `PDFShift.convert/3` and `PDFShift.credits_usage/1` to propagate the error via `with`
- Update tests to pass an explicit `api_key:` in cases that don't test key handling, and add tests for the missing-key error path