### PR TITLE
docs: sync README installation version with releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An Elixir client for the [PDFShift API](https://pdfshift.io), which allows you t
 
 The package can be installed by adding `pdf_shift` to your list of dependencies in `mix.exs`:
 
+<!-- x-release-please-start-version -->
 ```elixir
 def deps do
   [
@@ -17,6 +18,7 @@ def deps do
   ]
 end
 ```
+<!-- x-release-please-end -->
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package can be installed by adding `pdf_shift` to your list of dependencies 
 ```elixir
 def deps do
   [
-    {:pdf_shift, "~> 0.1.0"}
+    {:pdf_shift, "~> 0.2.0"}
   ]
 end
 ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,10 @@
 {
   "packages": {
     ".": {
-      "release-type": "elixir"
+      "release-type": "elixir",
+      "extra-files": [
+        "README.md"
+      ]
     }
   }
 }


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Update the installation snippet from `0.1.0` to `0.2.0` to match the current release
- Add `<!-- x-release-please-start-version -->` / `<!-- x-release-please-end -->` block annotations around the installation snippet so the generic updater can locate the version string
- Register `README.md` in `release-please-config.json` via `extra-files` so future release PRs bump the snippet automatically alongside `mix.exs`

## Test plan

- [x] Confirm README shows `~> 0.2.0` in the installation snippet
- [x] After merging, trigger a release-please PR and verify it updates both `mix.exs` and `README.md`