### PR TITLE
chore(docs): add badge for test coverage status from coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PDFShift
 
 [![Continuous Integration](https://github.com/sgerrand/ex_pdf_shift/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sgerrand/ex_pdf_shift/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/sgerrand/ex_pdf_shift/badge.svg?branch=main)](https://coveralls.io/github/sgerrand/ex_pdf_shift?branch=main)
 [![Hex Version](https://img.shields.io/hexpm/v/pdf_shift.svg)](https://hex.pm/packages/pdf_shift)
 [![Hex Docs](https://img.shields.io/badge/docs-hexpm-blue.svg)](https://hexdocs.pm/pdf_shift/)
 


### PR DESCRIPTION
💁 These changes add a status badge for the test coverage status as reported by [coveralls](https://coveralls.io).