### PR TITLE
fix: eliminate retry wait times in tests

### DIFF
--- a/lib/pdf_shift/client.ex
+++ b/lib/pdf_shift/client.ex
@@ -13,12 +13,15 @@ defmodule PDFShift.Client do
   def get(config, endpoint, client_opts \\ []) do
     url = "#{config.base_url}#{endpoint}"
 
-    Req.get(url,
-      auth: {:basic, "api:#{config.api_key}"},
-      receive_timeout: Keyword.get(client_opts, :timeout, 30_000),
-      retry: Keyword.get(client_opts, :retry, retry_options()),
-      connect_options: [protocols: [:http1]],
-      json: true
+    Req.get(
+      url,
+      [
+        auth: {:basic, "api:#{config.api_key}"},
+        receive_timeout: Keyword.get(client_opts, :timeout, 30_000),
+        retry: Keyword.get(client_opts, :retry, retry_options()),
+        connect_options: [protocols: [:http1]],
+        json: true
+      ] ++ retry_delay_opts(client_opts)
     )
     |> handle_response()
   end
@@ -31,12 +34,15 @@ defmodule PDFShift.Client do
   def post(config, endpoint, payload, client_opts \\ []) do
     url = "#{config.base_url}#{endpoint}"
 
-    Req.post(url,
-      auth: {:basic, "api:#{config.api_key}"},
-      json: payload,
-      receive_timeout: Keyword.get(client_opts, :timeout, 60_000),
-      retry: Keyword.get(client_opts, :retry, retry_options()),
-      connect_options: [protocols: [:http1]]
+    Req.post(
+      url,
+      [
+        auth: {:basic, "api:#{config.api_key}"},
+        json: payload,
+        receive_timeout: Keyword.get(client_opts, :timeout, 60_000),
+        retry: Keyword.get(client_opts, :retry, retry_options()),
+        connect_options: [protocols: [:http1]]
+      ] ++ retry_delay_opts(client_opts)
     )
     |> handle_response()
   end
@@ -47,6 +53,20 @@ defmodule PDFShift.Client do
       false
     else
       :safe_transient
+    end
+  end
+
+  # In test mode, force retry_delay to 0 so any retry-enabled test doesn't wait on backoff.
+  # Outside test mode, omit the option entirely and let Req use its default backoff.
+  defp retry_delay_opts(client_opts) do
+    if Keyword.has_key?(client_opts, :retry_delay) do
+      [retry_delay: Keyword.fetch!(client_opts, :retry_delay)]
+    else
+      if Application.get_env(:pdf_shift, :test_mode) do
+        [retry_delay: 0]
+      else
+        []
+      end
     end
   end
 

--- a/test/pdf_shift/client_test.exs
+++ b/test/pdf_shift/client_test.exs
@@ -27,7 +27,7 @@ defmodule PDFShift.ClientTest do
       end)
 
       {:ok, response} =
-        Client.get(config, "/test-endpoint", retry: fn _attempt, _error -> true end)
+        Client.get(config, "/test-endpoint", retry: false)
 
       assert response.status == 200
       assert response.body["success"] == true
@@ -106,9 +106,7 @@ defmodule PDFShift.ClientTest do
       end)
 
       {:ok, response} =
-        Client.post(config, "/test-endpoint", %{key: "value"},
-          retry: fn _attempt, _error -> true end
-        )
+        Client.post(config, "/test-endpoint", %{key: "value"}, retry: false)
 
       assert response.status == 200
       assert response.body["success"] == true


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Fix two "handles successful response" tests that used `retry: fn _attempt, _error -> true end`, causing Req to retry on 200 responses and wait through the full exponential backoff (1 s + 2 s + 4 s = 7 s per test). Replace with `retry: false` — these tests verify success-path behaviour, not retry logic.
- Add `retry_delay_opts/1` to `PDFShift.Client` which injects `retry_delay: 0` when `test_mode` is set, so any future retry-path test won't wait on backoff either.

## Test plan

- [x] `mix test` passes with no retry warnings and completes in < 1 s
- [x] `mix test test/pdf_shift/client_test.exs` shows no `[warning] retry:` lines in output