### PR TITLE
ci(deps): scope elixir dependabot group to dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
     groups:
       elixir:
         applies-to: version-updates
+        dependency-type: development
         patterns:
           - "*"
       security:


### PR DESCRIPTION
:tipping_hand_person: These changes restrict the `elixir` version-updates group in Dependabot to development dependencies (`dependency-type: development`), so production deps are no longer grouped together with dev tooling.

## Why

Keeps production dependency bumps as separate PRs from dev tooling bumps, making review and risk assessment clearer.