### PR TITLE
ci: add Elixir 1.20 / OTP 29 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,41 +62,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.15', '1.16', '1.17', '1.18', '1.19', '1.20']
-        otp: ['25', '26', '27', '28', '29']
-        exclude:
-          - elixir: '1.15'
-            otp: '27'
-          - elixir: '1.15'
-            otp: '28'
-          - elixir: '1.15'
-            otp: '29'
-          - elixir: '1.16'
-            otp: '27'
-          - elixir: '1.16'
-            otp: '28'
-          - elixir: '1.16'
-            otp: '29'
-          - elixir: '1.17'
-            otp: '28'
-          - elixir: '1.17'
-            otp: '29'
-          - elixir: '1.18'
-            otp: '28'
-          - elixir: '1.18'
-            otp: '29'
-          - elixir: '1.19'
-            otp: '25'
-          - elixir: '1.19'
-            otp: '29'
-          - elixir: '1.20'
-            otp: '25'
-          - elixir: '1.20'
-            otp: '26'
         include:
-          - elixir: '1.20'
-            otp: '29'
-            lint: true
+          - { elixir: '1.15', otp: '25' }
+          - { elixir: '1.15', otp: '26' }
+          - { elixir: '1.16', otp: '25' }
+          - { elixir: '1.16', otp: '26' }
+          - { elixir: '1.17', otp: '25' }
+          - { elixir: '1.17', otp: '26' }
+          - { elixir: '1.17', otp: '27' }
+          - { elixir: '1.18', otp: '25' }
+          - { elixir: '1.18', otp: '26' }
+          - { elixir: '1.18', otp: '27' }
+          - { elixir: '1.19', otp: '26' }
+          - { elixir: '1.19', otp: '27' }
+          - { elixir: '1.19', otp: '28' }
+          - { elixir: '1.20', otp: '27' }
+          - { elixir: '1.20', otp: '28' }
+          - { elixir: '1.20', otp: '29', lint: true }
 
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,16 +62,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.15', '1.16', '1.17', '1.18']
-        otp: ['25', '26', '27']
+        elixir: ['1.15', '1.16', '1.17', '1.18', '1.19', '1.20']
+        otp: ['25', '26', '27', '28', '29']
         exclude:
           - elixir: '1.15'
             otp: '27'
+          - elixir: '1.15'
+            otp: '28'
+          - elixir: '1.15'
+            otp: '29'
           - elixir: '1.16'
             otp: '27'
-        include:
+          - elixir: '1.16'
+            otp: '28'
+          - elixir: '1.16'
+            otp: '29'
+          - elixir: '1.17'
+            otp: '28'
+          - elixir: '1.17'
+            otp: '29'
           - elixir: '1.18'
-            otp: '27'
+            otp: '28'
+          - elixir: '1.18'
+            otp: '29'
+          - elixir: '1.19'
+            otp: '25'
+          - elixir: '1.19'
+            otp: '29'
+          - elixir: '1.20'
+            otp: '25'
+          - elixir: '1.20'
+            otp: '26'
+        include:
+          - elixir: '1.20'
+            otp: '29'
             lint: true
 
     env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18-otp-27
-erlang 27.2
+elixir 1.20-otp-29
+erlang 29.0.1


### PR DESCRIPTION
:tipping_hand_person: These changes add Elixir 1.19 and 1.20 and Erlang/OTP 28 and 29 to the CI test matrix, and bump the local/docs toolchain to the latest releases.

## Changes

- Extend the test matrix to Elixir 1.15–1.20 × OTP 25–29, excluding incompatible combinations (16 jobs).
- Move the lint and coverage job to Elixir 1.20 / OTP 29.
- Bump `.tool-versions` to Elixir 1.20 and Erlang 29.0.1 (read by the docs CI job and local dev).

## Notes

OTP 29 is only compatible with Elixir 1.20 (1.19 caps at OTP 28), so 1.20 was added alongside 1.19.