### PR TITLE
ci: migrate release workflow to release-mate/action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,17 +5,17 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+      - uses: release-mate/action@71f10a09c0b5161420efe386fdfa657f9f7d5688 # v1.1.1
         with:
+          client-id: ${{ secrets.RELEASE_MATE_CLIENT_ID }}
+          app-private-key: ${{ secrets.RELEASE_MATE_PRIVATE_KEY }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: Release
 
 on:
   push:
@@ -8,8 +8,8 @@ on:
 permissions: {}
 
 jobs:
-  release-please:
-    name: Release Please
+  release-mate:
+    name: Release Mate
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,3 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASE_MATE_CLIENT_ID }}
           app-private-key: ${{ secrets.RELEASE_MATE_PRIVATE_KEY }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
:tipping_hand_person: These changes migrate the release workflow from `googleapis/release-please-action` to `release-mate/action`.

## What changed
- Swap to `release-mate/action@v1.1.1` (SHA-pinned)
- Authenticate via the Release Mate GitHub App instead of `RELEASE_PLEASE_PAT`
- Drop `contents` / `pull-requests` write permissions — the App token supplies its own scope
- `release-please-config.json` and `.release-please-manifest.json` unchanged

## Required before merge
- [x] Register the Release Mate GitHub App on the org/repo
- [x] Add secrets `RELEASE_MATE_CLIENT_ID` and `RELEASE_MATE_PRIVATE_KEY`
- [ ] After confirmed working, revoke the old `RELEASE_PLEASE_PAT`