### PR TITLE
fix: send GET requests without a body

### DIFF
--- a/lib/pdf_shift/client.ex
+++ b/lib/pdf_shift/client.ex
@@ -19,8 +19,7 @@ defmodule PDFShift.Client do
         auth: {:basic, "api:#{config.api_key}"},
         receive_timeout: Keyword.get(client_opts, :timeout, 30_000),
         retry: Keyword.get(client_opts, :retry, retry_options()),
-        connect_options: [protocols: [:http1]],
-        json: true
+        connect_options: [protocols: [:http1]]
       ] ++ retry_delay_opts(client_opts)
     )
     |> handle_response()

--- a/test/pdf_shift/client_test.exs
+++ b/test/pdf_shift/client_test.exs
@@ -21,6 +21,9 @@ defmodule PDFShift.ClientTest do
   describe "get/3" do
     test "handles successful response", %{bypass: bypass, config: config} do
       Bypass.expect(bypass, "GET", "/test-endpoint", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body == ""
+
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.resp(200, Jason.encode!(%{success: true, data: "test"}))


### PR DESCRIPTION
:tipping_hand_person: These changes fix `Client.get/3` sending a request body on every GET.

## Problem

`Client.get/3` passed `json: true` to `Req.get`. In Req, `:json` is a request *body* option, not a response-decode flag, so every GET shipped a body of `true`. Response JSON decoding was never affected by it — Req decodes based on the response content-type regardless.

The stray body is harmless-looking on Req 0.6 but fatal on Req 0.7, which introduced this breaking change:

> `encode_body`: **(BREAKING CHANGE)** Automatically change GET to POST when request body is set.

So on Req 0.7 every GET goes out as a POST, breaking `/credits/usage`. Against Req 0.7.2 the suite fails 5 tests — every GET test that hits Bypass — each with `Request: POST /test-endpoint` against a `Bypass.expect(bypass, "GET", ...)`.

## Changes

- Drop `json: true` from `Req.get` in `PDFShift.Client`.
- Assert the GET request body is empty, mirroring the existing check in the `post/4` test.

## Verification

| Config | Result |
| --- | --- |
| Req 0.6.2 (current lock), fixed | 28 passed |
| Req 0.7.2, fixed | 28 passed |
| Req 0.6.2, `json: true` restored, new assertion active | 1 failed — `left: "true"` / `right: ""` |